### PR TITLE
Remove duplicated logs

### DIFF
--- a/pyms/flask/app/__init__.py
+++ b/pyms/flask/app/__init__.py
@@ -32,7 +32,7 @@ class Microservice:
         config = get_conf(service=self.service)
         app = connexion.App(__name__, specification_dir=os.path.join(self.path, 'swagger'))
         app.add_api('swagger.yaml',
-                    arguments={'title': 'Swagger Example project'},
+                    arguments={'title': config.APP_NAME},
                     base_path=config.APPLICATION_ROOT
                     )
 

--- a/pyms/flask/app/__init__.py
+++ b/pyms/flask/app/__init__.py
@@ -57,6 +57,7 @@ class Microservice:
             formatter.add_trace_span(self.application.tracer)
             log_handler.setFormatter(formatter)
             self.application.logger.addHandler(log_handler)
+            self.application.logger.propagate = False
             self.application.logger.setLevel(logging.INFO)
 
         return self.application

--- a/pyms/flask/app/__init__.py
+++ b/pyms/flask/app/__init__.py
@@ -38,7 +38,7 @@ class Microservice:
 
         self.application = app.app
         self.application._connexion_app = app
-        self.application.config.from_object(get_conf(service=self.service))
+        self.application.config.from_object(config)
         self.application.tracer = None
 
         # Initialize Blueprints


### PR DESCRIPTION
Flask duplicate the logs with our logger and the root logger, for example:

```bash
{"timestamp": "2018-12-03T16:36:05.771465Z", "level": null, "name": "flask.app", "module": "views", "funcName": "list_view", "lineno": 14, "message": "Return all color list", "severity": "INFO", "service": "template", "trace": "9ec64436ec28fc2c", "span": "9ec64436ec28fc2c", "parent": ""}
INFO:flask.app:Return all color list
```
With this change, Flask prints our logs and no more
