### PR TITLE
Fix requests service with no config

### DIFF
--- a/pyms/config/__init__.py
+++ b/pyms/config/__init__.py
@@ -1,0 +1,4 @@
+from pyms.config.conf import get_conf
+from pyms.config.confile import ConfFile
+
+__all__ = ['get_conf', 'ConfFile']

--- a/pyms/config/confile.py
+++ b/pyms/config/confile.py
@@ -35,8 +35,8 @@ class ConfFile(dict):
             kwargs=kwargs,
         ))
 
-        config = {k: v for k, v in self.normalize_config(config)}
-        [setattr(self, k, v) for k, v in config.items()]
+        config = dict(self.normalize_config(config))
+        _ = [setattr(self, k, v) for k, v in config.items()]
         super(ConfFile, self).__init__(config)
 
     def normalize_config(self, config):

--- a/pyms/flask/app/create_app.py
+++ b/pyms/flask/app/create_app.py
@@ -1,16 +1,17 @@
 import logging
 import os
+from typing import Text
 
 import connexion
 from flask import Flask
 from flask_opentracing import FlaskTracing
 
-from pyms.config.conf import get_conf
+from pyms.config import get_conf
 from pyms.constants import LOGGER_NAME, SERVICE_ENVIRONMENT
 from pyms.flask.healthcheck import healthcheck_blueprint
 from pyms.flask.services.driver import ServicesManager
 from pyms.logger import CustomJsonFormatter
-from pyms.utils.utils import check_package_exists
+from pyms.utils import check_package_exists
 
 logger = logging.getLogger(LOGGER_NAME)
 
@@ -56,7 +57,7 @@ class Microservice(metaclass=SingletonMeta):
         return self.application
 
     def init_tracer(self):
-        if getattr(self, "tracer", False) and self.tracer:
+        if self._exists_service("tracer"):
             client = self.tracer.get_client()
             self.application.tracer = FlaskTracing(client, True, self.application)
 
@@ -78,7 +79,7 @@ class Microservice(metaclass=SingletonMeta):
             self.application.logger.setLevel(logging.INFO)
 
     def init_app(self) -> Flask:
-        if getattr(self, "swagger", False) and self.swagger:
+        if self._exists_service("swagger"):
             check_package_exists("connexion")
             app = connexion.App(__name__, specification_dir=os.path.join(self.path, self.swagger.path))
             app.add_api(
@@ -122,6 +123,10 @@ class Microservice(metaclass=SingletonMeta):
         self.init_logger()
 
         return self.application
+
+    def _exists_service(self, service_name: Text) -> bool:
+        service = getattr(self, service_name, False)
+        return service and service is not None
 
     def add_error_handlers(self):
         """Subclasses will override this method in order to add specific error handlers. This should be done with

--- a/pyms/flask/services/driver.py
+++ b/pyms/flask/services/driver.py
@@ -1,14 +1,15 @@
 import logging
 
-from pyms.config.conf import get_conf
+from pyms.config import get_conf, ConfFile
 from pyms.constants import SERVICE_BASE, LOGGER_NAME
-from pyms.utils.utils import import_from
+from pyms.utils import import_from
 
 logger = logging.getLogger(LOGGER_NAME)
 
 
 class DriverService:
     service = ""
+    config = None
 
     def __init__(self, service, *args, **kwargs):
         self.service = ".".join([service, self.service])
@@ -18,6 +19,9 @@ class DriverService:
         config_attribute = getattr(self.config, attr)
         return config_attribute if config_attribute == "" or config_attribute != {} else self.default_values.get(attr,
                                                                                                                  None)
+
+    def exists_config(self):
+        return self.config is not None and isinstance(self.config, ConfFile)
 
 
 class ServicesManager:

--- a/pyms/flask/services/requests.py
+++ b/pyms/flask/services/requests.py
@@ -24,8 +24,8 @@ def retry(f):
         response = False
         i = 0
         response_ok = False
-        retries = args[0].retries
-        status_retries = args[0].status_retries
+        retries = args[0]._retries
+        status_retries = args[0]._status_retries
         while i < retries and response_ok is False:
             response = f(*args, **kwargs)
             i += 1
@@ -35,6 +35,7 @@ def retry(f):
         if not response_ok:
             logger.warning("Response ERROR: {}".format(response))
         return response
+
     return wrapper
 
 
@@ -44,12 +45,17 @@ class Service(DriverService):
         "data": ""
     }
     tracer = None
+    _retries = DEFAULT_RETRIES
+    _status_retries = DEFAULT_STATUS_RETRIES
+    _propagate_headers = False
 
     def __init__(self, service, *args, **kwargs):
         """Initialization for trace headers propagation"""
         super().__init__(service, *args, **kwargs)
-        self.retries = self.config.retries or DEFAULT_RETRIES
-        self.status_retries = self.config.status_retries or DEFAULT_STATUS_RETRIES
+        if self.exists_config():
+            self._retries = self.config.retries or DEFAULT_RETRIES
+            self._status_retries = self.config.status_retries or DEFAULT_STATUS_RETRIES
+            self._propagate_headers = self.config.propagate_headers
 
     def requests(self, session: requests.Session):
         """
@@ -62,11 +68,11 @@ class Service(DriverService):
         """
         session_r = session or requests.Session()
         retry = Retry(
-            total=self.retries,
-            read=self.retries,
-            connect=self.retries,
+            total=self._retries,
+            read=self._retries,
+            connect=self._retries,
             backoff_factor=0.3,
-            status_forcelist=self.status_retries,
+            status_forcelist=self._status_retries,
         )
         adapter = HTTPAdapter(max_retries=retry)
         session_r.mount('http://', adapter)
@@ -94,7 +100,8 @@ class Service(DriverService):
             logger.debug("Tracer error {}".format(ex))
         return headers
 
-    def propagate_headers(self, headers: dict) -> dict:
+    @staticmethod
+    def propagate_headers(headers: dict) -> dict:
         for k, v in request.headers:
             if not headers.get(k):
                 headers.update({k: v})
@@ -114,7 +121,7 @@ class Service(DriverService):
         self.tracer = current_app.tracer
         if self.tracer:
             headers = self.insert_trace_headers(headers)
-        if self.config.propagate_headers or propagate_headers:
+        if self._propagate_headers or propagate_headers:
             headers = self.propagate_headers(headers)
         return headers
 
@@ -164,7 +171,7 @@ class Service(DriverService):
         full_url = self._build_url(url, path_params)
         headers = self._get_headers(headers=headers, propagate_headers=propagate_headers)
         logger.debug("Get with url {}, params {}, headers {}, kwargs {}".
-                    format(full_url, params, headers, kwargs))
+                     format(full_url, params, headers, kwargs))
 
         session = requests.Session()
         response = self.requests(session=session).get(full_url, params=params, headers=headers, **kwargs)
@@ -205,7 +212,7 @@ class Service(DriverService):
         full_url = self._build_url(url, path_params)
         headers = self._get_headers(headers)
         logger.debug("Post with url {}, data {}, json {}, headers {}, kwargs {}".format(full_url, data, json,
-                                                                                       headers, kwargs))
+                                                                                        headers, kwargs))
 
         session = requests.Session()
         response = self.requests(session=session).post(full_url, data=data, json=json, headers=headers, **kwargs)
@@ -248,7 +255,7 @@ class Service(DriverService):
         full_url = self._build_url(url, path_params)
         headers = self._get_headers(headers)
         logger.debug("Put with url {}, data {}, headers {}, kwargs {}".format(full_url, data, headers,
-                                                                             kwargs))
+                                                                              kwargs))
 
         session = requests.Session()
         response = self.requests(session=session).put(full_url, data, headers=headers, **kwargs)

--- a/pyms/flask/services/tracer.py
+++ b/pyms/flask/services/tracer.py
@@ -2,7 +2,7 @@ import logging
 
 from pyms.constants import LOGGER_NAME
 from pyms.flask.services.driver import DriverService
-from pyms.utils.utils import check_package_exists, import_package, import_from
+from pyms.utils import check_package_exists, import_package, import_from
 
 logger = logging.getLogger(LOGGER_NAME)
 

--- a/pyms/flask/services/tracer.py
+++ b/pyms/flask/services/tracer.py
@@ -4,7 +4,7 @@ from jaeger_client.metrics.prometheus import PrometheusMetricsFactory
 
 from pyms.constants import LOGGER_NAME
 from pyms.flask.services.driver import DriverService
-from pyms.utils.utils import check_package_exists, import_package, import_from
+from pyms.utils import check_package_exists, import_package, import_from
 from pyms.config.conf import get_conf
 
 logger = logging.getLogger(LOGGER_NAME)

--- a/pyms/utils/__init__.py
+++ b/pyms/utils/__init__.py
@@ -1,0 +1,3 @@
+from pyms.utils.utils import import_from, import_package, check_package_exists
+
+__all__ = ['import_from', 'import_package', 'check_package_exists']

--- a/tests/config-tests-requests-no-data.yml
+++ b/tests/config-tests-requests-no-data.yml
@@ -1,0 +1,19 @@
+pyms:
+  requests: true
+  swagger:
+    path: ""
+    file: "swagger.yaml"
+  tracer:
+    client: "jaeger"
+    host: "localhost"
+    component_name: "Python Microservice"
+my-ms:
+  DEBUG: true
+  TESTING: true
+  APP_NAME: "Python Microservice"
+  APPLICATION_ROOT: /
+  test_var: general
+  subservice1:
+     test: input
+  subservice2:
+     test: output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,7 @@ import os
 import unittest
 from unittest import mock
 
-from pyms.config.conf import get_conf
-from pyms.config.confile import ConfFile
+from pyms.config import get_conf, ConfFile
 from pyms.constants import CONFIGMAP_FILE_ENVIRONMENT, LOGGER_NAME
 from pyms.exceptions import AttrDoesNotExistException, ConfigDoesNotFoundException, ServiceDoesNotExistException
 
@@ -110,7 +109,6 @@ class ConfNotExistTests(unittest.TestCase):
     def test_empty_conf_three_levels(self):
         config = ConfFile(empty_init=True)
         self.assertEqual(config.my_ms.level_two.level_three, {})
-
 
 
 class GetConfig(unittest.TestCase):

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -48,7 +48,7 @@ class HomeWithFlaskTests(unittest.TestCase):
 
 class MicroserviceTest(unittest.TestCase):
     """
-    Tests for healthcheack endpoints
+    Tests for Singleton
     """
 
     def setUp(self):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -12,6 +12,33 @@ from pyms.flask.app import Microservice
 from pyms.flask.services.requests import DEFAULT_RETRIES
 
 
+class RequestServiceNoDataTests(unittest.TestCase):
+    """Test common rest operations wrapper.
+    """
+
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    def setUp(self):
+        os.environ[CONFIGMAP_FILE_ENVIRONMENT] = os.path.join(self.BASE_DIR, "config-tests-requests-no-data.yml")
+        ms = Microservice(service="my-ms", path=__file__)
+        self.app = ms.create_app()
+        self.request = ms.requests
+
+    @requests_mock.Mocker()
+    def test_get(self, mock_request):
+        url = "http://www.my-site.com/users"
+        full_url = url
+        text = json.dumps([{'id': 1, 'name': 'Peter', 'email': 'peter@my-site.com.com'},
+                                    {'id': 2, 'name': 'Jon', 'email': 'jon@my-site.com.com'}])
+
+        with self.app.app_context():
+            mock_request.get(full_url, text=text)
+            response = self.request.get(url)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(text, response.text)
+
+
 class RequestServiceTests(unittest.TestCase):
     """Test common rest operations wrapper.
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import unittest
 import pytest
 
 from pyms.exceptions import PackageNotExists
-from pyms.utils.utils import check_package_exists, import_package
+from pyms.utils import check_package_exists, import_package
 
 
 class ConfUtils(unittest.TestCase):


### PR DESCRIPTION
**Fix**
* backward compatible requests service. If we have the old way to init requests raise a exception like:
```
pyms:
  requests: true
```
