### PR TITLE
WIP: Add service name label by default

### DIFF
--- a/pyms/flask/services/tracer.py
+++ b/pyms/flask/services/tracer.py
@@ -68,7 +68,8 @@ class Service(DriverService):
         metrics_config = get_conf(service="pyms.metrics", empty_init=True, memoize=False)
         metrics = ""
         if metrics_config:
-            metrics = PrometheusMetricsFactory()
+            service_name = self.component_name.lower().replace("-", "_").replace(" ", "_")
+            metrics = PrometheusMetricsFactory(service_name_label=service_name)
         config = Config(
             config={
                 **{


### PR DESCRIPTION
It adds a label to all jaeger's generated metrics that can be used to identify every microservice.

See https://github.com/jaegertracing/jaeger-client-python/pull/269.