### PR TITLE
Human readable config errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Alberto Vara <a.vara.1986@gmail.com>
+Àlex Pérez <alexperezpujol@disroot.org>
 Hugo Camino <hugo.camino.villacorta@gmail.com>
-José Manuel <jmrivas86@gmail.com>
 Javier Luna molina <javierlunamolina@gmail.com>
-pilamb <perikopalotes@gmail.com>
+José Manuel <jmrivas86@gmail.com>
+Mike Rubin <miguelgr1988@gmail.com>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ microservices with Python which handles cross-cutting concerns:
 - Externalized configuration
 - Logging
 - Health checks
-- Metrics (TODO)
+- Metrics
 - Distributed tracing
 
 PyMS is powered by [Flask](https://flask.palletsprojects.com/en/1.1.x/), [Connexion](https://github.com/zalando/connexion) and [Opentracing](https://opentracing.io/).

--- a/docs/ms_class.md
+++ b/docs/ms_class.md
@@ -37,19 +37,19 @@ Each keyword in our configuration block, can be accessed in our Microservice obj
 ```yaml
 # Config.yml
 pyms:
-	config:
-		app_name: "Python Microservice"
-		foo: "var"
-		multiplevars:
-			config1: "test1"
-			config2: "test2"
+  config:
+    app_name: "Python Microservice"
+      foo: "var"
+        multiplevars:
+          config1: "test1"
+          config2: "test2"
   
 ```
 ```python
 #app.py
 from pyms.flask.app import Microservice
 
-ms = Microservice(service="example-config", path=__file__)
+ms = Microservice(path=__file__)
 print(ms.config.APP_NAME) 
 # >> "Python Microservice"
 print(ms.config.app_name) 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,14 +26,14 @@ if __name__ == '__main__':
 config.yml
 ```yaml
 pyms: 
-	services: # 1.2
-		requests:
-			data: {}
-	config: # 1.3
-		DEBUG: true
-		APP_NAME: business-glossary
-		APPLICATION_ROOT : ""
-		SECRET_KEY: "gjr39dkjn344_!67#"
+  services: # 1.2
+    requests:
+      data: {}
+  config: # 1.3
+    DEBUG: true
+    APP_NAME: business-glossary
+    APPLICATION_ROOT : ""
+    SECRET_KEY: "gjr39dkjn344_!67#"
 ```
 
 ## So what did that code do?

--- a/pyms/config/conf.py
+++ b/pyms/config/conf.py
@@ -1,5 +1,6 @@
 from pyms.config.confile import ConfFile
-from pyms.exceptions import ServiceDoesNotExistException
+from pyms.constants import PYMS_CONFIG_WHITELIST_KEYWORDS
+from pyms.exceptions import ServiceDoesNotExistException, ConfigErrorException, AttrDoesNotExistException
 
 
 def get_conf(*args, **kwargs):
@@ -8,26 +9,26 @@ def get_conf(*args, **kwargs):
     parent and this name, in example of the next yaml, tracer will be `pyms.tracer`. If we have got his config file:
     ```
     pyms:
-      metrics: true
-      requests:
-        data: data
-      swagger:
-        path: ""
-        file: "swagger.yaml"
-      tracer:
-        client: "jaeger"
-        host: "localhost"
-        component_name: "Python Microservice"
-    my-ms:
-      DEBUG: true
-      TESTING: true
+      services:
+        metrics: true
+        requests:
+          data: data
+        swagger:
+          path: ""
+          file: "swagger.yaml"
+        tracer:
+          client: "jaeger"
+          host: "localhost"
+          component_name: "Python Microservice"
+      config:
+        DEBUG: true
+        TESTING: true
     ```
-    * `pyms` block is the default key to load in the pyms.flask.app.create_app.Microservice class.
+    * `pyms.services`: block is the default key to load in the pyms.flask.app.create_app.Microservice class.
         * `metrics`: is set as the service `pyms.metrics`
         * `swagger`: is set as the service `pyms.swagger`
         * `tracer`: is set as the service `pyms.tracer`
-    * `my-ms` block is defined by the env var `CONFIGMAP_SERVICE`. By default is `ms`. This block is the default flask
-    block config
+    * `pyms.config`: This block is the default flask block config
     :param args:
     :param kwargs:
 
@@ -36,6 +37,70 @@ def get_conf(*args, **kwargs):
     service = kwargs.pop('service', None)
     if not service:
         raise ServiceDoesNotExistException("Service not defined")
-
     config = ConfFile(*args, **kwargs)
     return getattr(config, service)
+
+
+def validate_conf(*args, **kwargs):
+    config = ConfFile(*args, **kwargs)
+    is_config_ok = True
+    try:
+        config.pyms
+    except AttrDoesNotExistException:
+        is_config_ok = False
+    if not is_config_ok:
+        raise ConfigErrorException("""Config file must start with `pyms` keyword, for example:
+    pyms:
+      services:
+        metrics: true
+        requests:
+          data: data
+        swagger:
+          path: ""
+          file: "swagger.yaml"
+        tracer:
+          client: "jaeger"
+          host: "localhost"
+          component_name: "Python Microservice"
+      config:
+        DEBUG: true
+        TESTING: true""")
+    try:
+        config.pyms.config
+    except AttrDoesNotExistException:
+        is_config_ok = False
+    if not is_config_ok:
+        raise ConfigErrorException("""`pyms` block must contain a `config` keyword in your Config file, for example:
+    pyms:
+      services:
+        metrics: true
+        requests:
+          data: data
+        swagger:
+          path: ""
+          file: "swagger.yaml"
+        tracer:
+          client: "jaeger"
+          host: "localhost"
+          component_name: "Python Microservice"
+      config:
+        DEBUG: true
+        TESTING: true""")
+    wrong_keywords = [i for i in config.pyms if i not in PYMS_CONFIG_WHITELIST_KEYWORDS]
+    if len(wrong_keywords) > 0:
+        raise ConfigErrorException("""{} isn`t a valid keyword for pyms block, for example:
+        pyms:
+          services:
+            metrics: true
+            requests:
+              data: data
+            swagger:
+              path: ""
+              file: "swagger.yaml"
+            tracer:
+              client: "jaeger"
+              host: "localhost"
+              component_name: "Python Microservice"
+          config:
+            DEBUG: true
+            TESTING: true""".format(wrong_keywords))

--- a/pyms/constants.py
+++ b/pyms/constants.py
@@ -5,3 +5,5 @@ LOGGER_NAME = "pyms"
 CONFIG_BASE = "pyms.config"
 
 SERVICE_BASE = "pyms.services"
+
+PYMS_CONFIG_WHITELIST_KEYWORDS = ["config", "services"]

--- a/pyms/exceptions.py
+++ b/pyms/exceptions.py
@@ -16,6 +16,8 @@ class ServiceDoesNotExistException(Exception):
 class ConfigDoesNotFoundException(Exception):
     pass
 
+class ConfigErrorException(Exception):
+    pass
 
 class PackageNotExists(Exception):
     pass

--- a/pyms/exceptions.py
+++ b/pyms/exceptions.py
@@ -16,8 +16,10 @@ class ServiceDoesNotExistException(Exception):
 class ConfigDoesNotFoundException(Exception):
     pass
 
+
 class ConfigErrorException(Exception):
     pass
+
 
 class PackageNotExists(Exception):
     pass

--- a/pyms/flask/app/create_app.py
+++ b/pyms/flask/app/create_app.py
@@ -6,6 +6,7 @@ from flask import Flask
 from flask_opentracing import FlaskTracing
 
 from pyms.config import get_conf
+from pyms.config.conf import validate_conf
 from pyms.constants import LOGGER_NAME, CONFIG_BASE
 from pyms.flask.healthcheck import healthcheck_blueprint
 from pyms.flask.services.driver import ServicesManager
@@ -56,8 +57,6 @@ class Microservice(metaclass=SingletonMeta):
     Environments variables of PyMS:
     **CONFIGMAP_FILE**: The path to the configuration file. By default, PyMS search the configuration file in your
     actual folder with the name "config.yml"
-    **CONFIGMAP_SERVICE**: the name of the keyword that define the block of key-value of [Flask Configuration Handling](http://flask.pocoo.org/docs/1.0/config/)
-    and your own configuration (see the next section to more  info)
 
     ## Create configuration
     Each microservice needs a config file in yaml or json format to work with it. This configuration contains
@@ -99,6 +98,7 @@ class Microservice(metaclass=SingletonMeta):
 
     def __init__(self, *args, **kwargs):
         self.path = os.path.dirname(kwargs.get("path", __file__))
+        validate_conf()
         self.config = get_conf(service=CONFIG_BASE)
         self.init_services()
 

--- a/pyms/flask/app/create_config.py
+++ b/pyms/flask/app/create_config.py
@@ -4,8 +4,6 @@ from pyms.flask.app.create_app import Microservice
 def config():
     """The behavior of this function is to access to the configuration outer the scope of flask context, to prevent to
      raise a `'working outside of application context`
-    **IMPORTANT:** If you use this method to get configuration out of context, you must set the `CONFIGMAP_SERVICE` or
-    set the default key `ms` for your configuration block in your config.yml
     :return:
     """
     ms = Microservice()

--- a/pyms/flask/services/swagger.py
+++ b/pyms/flask/services/swagger.py
@@ -13,6 +13,13 @@ PROJECT_DIR = "project"
 
 
 class Service(DriverService):
+    """The parameters you can add to your config are:
+    * **path:** The relative or absolute route to your swagger yaml file. The default value is the current directory
+    * **file:** The name of you swagger yaml file. The default value is `swagger.yaml`
+    * **url:** The url where swagger run in your server. The default value is `/ui/`.
+    * **project_dir:** Relative path of the project folder to automatic routing,
+    see [this link for more info](https://github.com/zalando/connexion#automatic-routing). The default value is `project`
+    """
     service = "swagger"
     default_values = {
         "path": SWAGGER_PATH,

--- a/tests/config-tests-bad-structure.yml
+++ b/tests/config-tests-bad-structure.yml
@@ -1,0 +1,10 @@
+config:
+  debug: true
+  testing: true
+  app_name: "Python Microservice"
+  application_root: /
+  test_var: general
+  subservice1:
+     test: input
+  subservice2:
+     test: output

--- a/tests/config-tests-bad-structure2.yml
+++ b/tests/config-tests-bad-structure2.yml
@@ -1,0 +1,11 @@
+pyms:
+  config2:
+    debug: true
+    testing: true
+    app_name: "Python Microservice"
+    application_root: /
+    test_var: general
+    subservice1:
+       test: input
+    subservice2:
+       test: output

--- a/tests/config-tests-bad-structure3.yml
+++ b/tests/config-tests-bad-structure3.yml
@@ -1,0 +1,21 @@
+pyms:
+  metrics: true
+  requests:
+    data: data
+  swagger:
+    path: ""
+    file: "swagger.yaml"
+  tracer:
+    client: "jaeger"
+    host: "localhost"
+    component_name: "Python Microservice"
+  config:
+    debug: true
+    testing: true
+    app_name: "Python Microservice"
+    application_root: /
+    test_var: general
+    subservice1:
+       test: input
+    subservice2:
+       test: output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,10 @@ import unittest
 from unittest import mock
 
 from pyms.config import get_conf, ConfFile
+from pyms.config.conf import validate_conf
 from pyms.constants import CONFIGMAP_FILE_ENVIRONMENT, LOGGER_NAME, CONFIG_BASE
-from pyms.exceptions import AttrDoesNotExistException, ConfigDoesNotFoundException, ServiceDoesNotExistException
+from pyms.exceptions import AttrDoesNotExistException, ConfigDoesNotFoundException, ServiceDoesNotExistException, \
+    ConfigErrorException
 
 logger = logging.getLogger(LOGGER_NAME)
 
@@ -99,6 +101,7 @@ class ConfTests(unittest.TestCase):
 
 class ConfCacheTests(unittest.TestCase):
     BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
     def test_get_cache(self):
         config = ConfFile(path=os.path.join(self.BASE_DIR, "config-tests-cache.yml"))
         config.set_path(os.path.join(self.BASE_DIR, "config-tests-cache2.yml"))
@@ -148,3 +151,24 @@ class GetConfig(unittest.TestCase):
     def test_without_params(self, mock_confile):
         with self.assertRaises(ServiceDoesNotExistException):
             get_conf()
+
+
+class ConfValidateTests(unittest.TestCase):
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    def test_get_conf(self):
+        config = ConfFile(path=os.path.join(self.BASE_DIR, "config-tests-cache.yml"))
+        config.set_path(os.path.join(self.BASE_DIR, "config-tests-cache2.yml"))
+        self.assertEqual(config.pyms.config.my_cache, 1234)
+
+    def test_wrong_block_no_pyms(self):
+        with self.assertRaises(ConfigErrorException):
+            validate_conf(path=os.path.join(self.BASE_DIR, "config-tests-bad-structure.yml"))
+
+    def test_wrong_block_no_config(self):
+        with self.assertRaises(ConfigErrorException):
+            validate_conf(path=os.path.join(self.BASE_DIR, "config-tests-bad-structure2.yml"))
+
+    def test_wrong_block_not_valid_structure(self):
+        with self.assertRaises(ConfigErrorException):
+            validate_conf(path=os.path.join(self.BASE_DIR, "config-tests-bad-structure3.yml"))


### PR DESCRIPTION
Show more help information if the config file not have a good structure with error messages like

```
Config file must start with `pyms` keyword, for example:
    pyms:
      services:
        metrics: true
        requests:
          data: data
        swagger:
          path: ""
          file: "swagger.yaml"
        tracer:
          client: "jaeger"
          host: "localhost"
          component_name: "Python Microservice"
      config:
        DEBUG: true
        TESTING: true
```