### PR TITLE
Fix. Load config file from env

### DIFF
--- a/pyms/cmd/main.py
+++ b/pyms/cmd/main.py
@@ -72,7 +72,7 @@ class Command:
     def run(self):
         crypt = Crypt()
         if self.create_key:
-            path = crypt._loader.get_or_setpath()  # pylint: disable=protected-access
+            path = crypt._loader.get_path_from_env()  # pylint: disable=protected-access
             pwd = self.get_input('Type a password to generate the key file: ')
             generate_file = self.get_input('Do you want to generate a file in {}? [Y/n]'.format(path))
             generate_file = generate_file.lower() != "n"

--- a/pyms/config/confile.py
+++ b/pyms/config/confile.py
@@ -44,7 +44,8 @@ class ConfFile(dict):
             if self._empty_init:
                 config = {}
             else:
-                raise ConfigDoesNotFoundException("Configuration file not found")
+                path = self._loader.path if self._loader.path else ""
+                raise ConfigDoesNotFoundException("Configuration file {}not found".format(path + " "))
 
         config = self.set_config(config)
 

--- a/pyms/utils/crypt.py
+++ b/pyms/utils/crypt.py
@@ -54,4 +54,4 @@ class Crypt:
         return str(decrypted, encoding="utf-8")
 
     def delete_key(self):
-        os.remove(self._loader.get_or_setpath())
+        os.remove(self._loader.get_path_from_env())

--- a/pyms/utils/files.py
+++ b/pyms/utils/files.py
@@ -19,27 +19,24 @@ class LoadFile:
         self.default_file = default_filename
 
     def get_file(self, fn=None):
-        return self._get_conf_from_env(fn) or self._get_conf_from_file(fn)
+        return self._get_conf_from_env(fn) or self._get_conf_from_file(self.path, fn)
 
     def put_file(self, content, mode="w"):
-        self.get_or_setpath()
-        file_to_write = open(self.path, mode)
+        path = self.get_path_from_env()
+        file_to_write = open(path, mode)
         file_to_write.write(content)  # The key is type bytes still
         file_to_write.close()
 
-    def get_or_setpath(self):
+    def get_path_from_env(self):
         config_file = os.environ.get(self.file_env_location, self.default_file)
         logger.debug("Searching file in ENV[{}]: {}...".format(self.file_env_location, config_file))
-        self.path = config_file
-        return self.path
+        return config_file
 
     def _get_conf_from_env(self, fn=None):
-        self.get_or_setpath()
-        return self._get_conf_from_file(fn)
+        path = self.get_path_from_env()
+        return self._get_conf_from_file(path, fn)
 
-    def _get_conf_from_file(self, fn=None):
-        path = self.path
-
+    def _get_conf_from_file(self, path, fn=None):
         if path and os.path.isdir(path):
             path = os.path.join(path, self.default_file)
 
@@ -48,6 +45,7 @@ class LoadFile:
             return {}
         if path not in files_cached:
             logger.debug("[CONF] Configmap {} found".format(path))
+            self.path = path
             if fn:
                 files_cached[path] = fn(path)
             else:

--- a/pyms/utils/files.py
+++ b/pyms/utils/files.py
@@ -19,7 +19,7 @@ class LoadFile:
         self.default_file = default_filename
 
     def get_file(self, fn=None):
-        return self._get_conf_from_file(fn) or self._get_conf_from_env(fn)
+        return self._get_conf_from_env(fn) or self._get_conf_from_file(fn)
 
     def put_file(self, content, mode="w"):
         self.get_or_setpath()

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -19,7 +19,7 @@ class TestCmd(unittest.TestCase):
         cmd = Command(arguments=arguments, autorun=False)
         with pytest.raises(FileDoesNotExistException) as excinfo:
             cmd.run()
-        assert ("Decrypt key key.key not exists. You must set a correct env var KEY_FILE or run "
+        assert ("Decrypt key None not exists. You must set a correct env var KEY_FILE or run "
                 "`pyms crypt create-key` command") \
                in str(excinfo.value)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ class CryptUtils(unittest.TestCase):
         crypt = Crypt()
         with pytest.raises(FileDoesNotExistException) as excinfo:
             crypt.read_key()
-        assert ("Decrypt key key.key not exists. You must set a correct env var KEY_FILE or run "
+        assert ("Decrypt key None not exists. You must set a correct env var KEY_FILE or run "
                 "`pyms crypt create-key` command") \
                in str(excinfo.value)
 


### PR DESCRIPTION
If you set a config file from env, but exists a default file. PyMS load the default file first instead the env file