### PR TITLE
Fix swagger openapi 3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -78,10 +78,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
-            "version": "==7.0"
+            "version": "==7.1.1"
         },
         "clickclick": {
             "hashes": [
@@ -370,9 +370,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:0ec40d9fd4ec9f9e3ff9bdd12dbd3535f4085949f4db93025089d7a673ea94e8"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.12.0"
+            "version": "==1.12.1"
         },
         "zipp": {
             "hashes": [
@@ -430,6 +430,39 @@
             ],
             "version": "==2019.11.28"
         },
+        "cffi": {
+            "hashes": [
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
+            ],
+            "version": "==1.14.0"
+        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
@@ -439,10 +472,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
-            "version": "==7.0"
+            "version": "==7.1.1"
         },
         "coverage": {
             "hashes": [
@@ -479,6 +512,32 @@
                 "sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0"
             ],
             "version": "==5.0.3"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
+                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
+                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
+                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
+                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
+                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
+                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
+                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
+                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
+                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
+                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
+                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
+                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
+                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
+                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
+                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
+                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
+                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
+                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
+                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
+                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
+            ],
+            "version": "==2.8"
         },
         "distlib": {
             "hashes": [
@@ -783,6 +842,13 @@
             ],
             "version": "==2.5.0"
         },
+        "pycparser": {
+            "hashes": [
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+            ],
+            "version": "==2.20"
+        },
         "pyflakes": {
             "hashes": [
                 "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
@@ -792,10 +858,10 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b",
-                "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"
+                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
-            "version": "==2.5.2"
+            "version": "==2.6.1"
         },
         "pylint": {
             "hashes": [
@@ -820,10 +886,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
-                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
             ],
-            "version": "==5.3.5"
+            "version": "==5.4.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -957,10 +1023,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:0c04c7e8e0314470b4c2b43740ff68be1c62bb3fdef8309341ff1daea60d49d1",
-                "sha256:1f0369d068d9761b5c1ed7b44dad1ec124727eb10bc7f4aaefbba0cdca3bd924"
+                "sha256:10750cac3b5a9e6eed54d0f1f8222c550dc47f84609c95cbc504d44a58a048b8",
+                "sha256:8512e83f1d90f8e481024d58512ac9c053bf16f54d9138520a0929396820dd78"
             ],
-            "version": "==20.0.8"
+            "version": "==20.0.10"
         },
         "wcwidth": {
             "hashes": [
@@ -978,9 +1044,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:0ec40d9fd4ec9f9e3ff9bdd12dbd3535f4085949f4db93025089d7a673ea94e8"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.12.0"
+            "version": "==1.12.1"
         },
         "zipp": {
             "hashes": [

--- a/pyms/flask/services/swagger.py
+++ b/pyms/flask/services/swagger.py
@@ -32,7 +32,8 @@ class Service(DriverService):
         "project_dir": PROJECT_DIR
     }
 
-    def _get_application_root(self, config):
+    @staticmethod
+    def _get_application_root(config):
         try:
             application_root = config.APPLICATION_ROOT
         except AttrDoesNotExistException:
@@ -83,7 +84,6 @@ class Service(DriverService):
         # Fix Connexion issue https://github.com/zalando/connexion/issues/1135
         if application_root == "/":
             params["base_path"] = ""
-
 
         app.add_api(**params)
         # Invert the objects, instead connexion with a Flask object, a Flask object with

--- a/pyms/flask/services/swagger.py
+++ b/pyms/flask/services/swagger.py
@@ -3,6 +3,7 @@ import os
 import connexion
 from connexion.resolver import RestyResolver
 
+from pyms.exceptions import AttrDoesNotExistException
 from pyms.flask.services.driver import DriverService
 from pyms.utils import check_package_exists
 
@@ -31,6 +32,13 @@ class Service(DriverService):
         "project_dir": PROJECT_DIR
     }
 
+    def _get_application_root(self, config):
+        try:
+            application_root = config.APPLICATION_ROOT
+        except AttrDoesNotExistException:
+            application_root = "/"
+        return application_root
+
     def init_app(self, config, path):
         """
         Initialize Connexion App. See more info in [Connexion Github](https://github.com/zalando/connexion)
@@ -57,6 +65,7 @@ class Service(DriverService):
         """
         check_package_exists("connexion")
         specification_dir = self.path
+        application_root = self._get_application_root(config)
         if not os.path.isabs(self.path):
             specification_dir = os.path.join(path, self.path)
 
@@ -67,11 +76,14 @@ class Service(DriverService):
         params = {
             "specification": self.file,
             "arguments": {'title': config.APP_NAME},
+            "base_path": application_root,
             "options": {"swagger_url": self.url},
         }
+
         # Fix Connexion issue https://github.com/zalando/connexion/issues/1135
-        if config.APPLICATION_ROOT and config.APPLICATION_ROOT != "/":
-            params["base_path"] = config.APPLICATION_ROOT
+        if application_root == "/":
+            params["base_path"] = ""
+
 
         app.add_api(**params)
         # Invert the objects, instead connexion with a Flask object, a Flask object with

--- a/tests/config-tests-flask-swagger.yml
+++ b/tests/config-tests-flask-swagger.yml
@@ -7,7 +7,6 @@ pyms:
     DEBUG: true
     TESTING: true
     APP_NAME: "Python Microservice With Flask in tests"
-    APPLICATION_ROOT: /
     test_var: general
     subservice1:
        test: input

--- a/tests/config-tests-flask.yml
+++ b/tests/config-tests-flask.yml
@@ -3,7 +3,6 @@ pyms:
     DEBUG: true
     TESTING: true
     APP_NAME: "Python Microservice With Flask"
-    APPLICATION_ROOT: /
     test_var: general
     subservice1:
        test: input

--- a/tests/config-tests-metrics.yml
+++ b/tests/config-tests-metrics.yml
@@ -9,4 +9,4 @@ pyms:
     DEBUG: true
     TESTING: true
     APP_NAME: "Python Microservice with Jaeger"
-    APPLICATION_ROOT: /
+    APPLICATION_ROOT: "/"

--- a/tests/config-tests-swagger_3.yml
+++ b/tests/config-tests-swagger_3.yml
@@ -1,0 +1,13 @@
+pyms:
+  services:
+    metrics:
+      enabled: false
+    swagger:
+      path: ""
+      file: "swagger3.yaml"
+      url: "/ws-doc/"
+  config:
+    DEBUG: true
+    TESTING: true
+    APP_NAME: "Python Microservice Swagger Openapi 3"
+    APPLICATION_ROOT: ""

--- a/tests/config-tests-swagger_3_no_abs_path.yml
+++ b/tests/config-tests-swagger_3_no_abs_path.yml
@@ -1,0 +1,13 @@
+pyms:
+  services:
+    metrics:
+      enabled: false
+    swagger:
+      path: ""
+      file: "swagger3.yaml"
+      url: "/ws-doc2/"
+  config:
+    DEBUG: true
+    TESTING: true
+    APP_NAME: "Python Microservice Swagger Openapi 3 No abspath"
+    APPLICATION_ROOT: "/test-api-path2"

--- a/tests/config-tests.yml
+++ b/tests/config-tests.yml
@@ -14,7 +14,6 @@ pyms:
     debug: true
     testing: true
     app_name: "Python Microservice"
-    application_root: /
     test_var: general
     subservice1:
        test: input

--- a/tests/swagger3.yaml
+++ b/tests/swagger3.yaml
@@ -1,0 +1,21 @@
+---
+openapi: 3.0.2
+info:
+  title: Testing
+  version: 1.0.0
+  description: Testing
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Testing
+    email: test@test.com
+servers:
+- url: http://localhost:8080/test/path/
+  description: ""
+paths:
+  /test-url:
+    summary: get test
+    get:
+      responses:
+        "200":
+          description: OK
+      operationId: "tests.test_flask.home"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,7 @@ import unittest.mock
 from prometheus_client import generate_latest
 
 from pyms.constants import CONFIGMAP_FILE_ENVIRONMENT
-from tests.common import MyMicroservice
+from tests.common import MyMicroserviceNoSingleton
 
 
 class TestMetricsFlask(unittest.TestCase):
@@ -12,7 +12,7 @@ class TestMetricsFlask(unittest.TestCase):
 
     def setUp(self):
         os.environ[CONFIGMAP_FILE_ENVIRONMENT] = os.path.join(self.BASE_DIR, "config-tests-metrics.yml")
-        ms = MyMicroservice(path=__file__)
+        ms = MyMicroserviceNoSingleton(path=__file__)
         ms.reload_conf()
         self.app = ms.create_app()
         self.client = self.app.test_client()

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -49,3 +49,47 @@ class SwaggerNoAbsPathTests(unittest.TestCase):
     def test_home(self):
         response = self.client.get('/test-api-path2/no-abs-path')
         self.assertEqual(200, response.status_code)
+
+
+class SwaggerOpenapi3Tests(unittest.TestCase):
+    """Test common rest operations wrapper.
+    """
+
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    def setUp(self):
+        os.environ[CONFIGMAP_FILE_ENVIRONMENT] = os.path.join(self.BASE_DIR, "config-tests-swagger_3.yml")
+        ms = MyMicroserviceNoSingleton(path=__file__)
+        self.app = ms.create_app()
+        self.client = self.app.test_client()
+        self.assertEqual("Python Microservice Swagger Openapi 3", self.app.config["APP_NAME"])
+
+    def test_default(self):
+        response = self.client.get('/ws-doc/')
+        self.assertEqual(200, response.status_code)
+
+    def test_home(self):
+        response = self.client.get('/test-url')
+        self.assertEqual(200, response.status_code)
+
+
+class SwaggerOpenapi3NoAbsPathTests(unittest.TestCase):
+    """Test common rest operations wrapper.
+    """
+
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    def setUp(self):
+        os.environ[CONFIGMAP_FILE_ENVIRONMENT] = os.path.join(self.BASE_DIR, "config-tests-swagger_3_no_abs_path.yml")
+        ms = MyMicroserviceNoSingleton(path=__file__)
+        self.app = ms.create_app()
+        self.client = self.app.test_client()
+        self.assertEqual("Python Microservice Swagger Openapi 3 No abspath", self.app.config["APP_NAME"])
+
+    def test_default(self):
+        response = self.client.get('/test-api-path2/ws-doc2/')
+        self.assertEqual(200, response.status_code)
+
+    def test_home(self):
+        response = self.client.get('/test-api-path2/test-url')
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
If you use openapi 3 in your swagger yaml file:

```
---
openapi: 3.0.2
info:
  title: Testing
  version: 1.0.0
  description: Testing
  termsOfService: http://swagger.io/terms/
  contact:
    name: Testing
    email: test@test.com
servers:
- url: http://localhost:8080/test/path/
  description: ""
paths:
  /test-url:
```

and in your configuration file `APPLICATION_ROOT` is defined like

```
  config:
    DEBUG: false
    TESTING: false
    APP_NAME: Films&Actors
    APPLICATION_ROOT : ""
```

The servers.url in swagger file override the base path of your application