### PR TITLE
fix(metrics): use rule as path

### DIFF
--- a/pyms/flask/services/metrics.py
+++ b/pyms/flask/services/metrics.py
@@ -30,9 +30,14 @@ class FlaskMetricsWrapper():
         request.start_time = time.time()
 
     def after_request(self, response):
+        if hasattr(request.url_rule, "rule"):
+            path = request.url_rule.rule
+        else:
+            path = request.path
+
         request_latency = time.time() - request.start_time
-        FLASK_REQUEST_LATENCY.labels(self.app_name, request.method, request.path, response.status_code).observe(request_latency)
-        FLASK_REQUEST_COUNT.labels(self.app_name, request.method, request.path, response.status_code).inc()
+        FLASK_REQUEST_LATENCY.labels(self.app_name, request.method, path, response.status_code).observe(request_latency)
+        FLASK_REQUEST_COUNT.labels(self.app_name, request.method, path, response.status_code).inc()
 
         return response
 

--- a/pyms/flask/services/metrics.py
+++ b/pyms/flask/services/metrics.py
@@ -34,7 +34,6 @@ class FlaskMetricsWrapper():
             path = request.url_rule.rule
         else:
             path = request.path
-
         request_latency = time.time() - request.start_time
         FLASK_REQUEST_LATENCY.labels(self.app_name, request.method, path, response.status_code).observe(request_latency)
         FLASK_REQUEST_COUNT.labels(self.app_name, request.method, path, response.status_code).inc()


### PR DESCRIPTION
Using the real path as metric created useless metrics. When using a
dynamic rule, it creates unique paths with every metric, which makes it
impossible to aggregate metrics to the same endpoint.

For example, having the next endpoint:
```python
@self.app.route("/something/<myid>/update")
    def root(myid):
```

Created the next metrics:
```
http_server_requests_seconds_count{method="GET",uri="/something/1/update"} 4.0
http_server_requests_seconds_count{method="GET",uri="/something/2/update"} 4.0
http_server_requests_seconds_count{method="GET",uri="/something/3/update"} 4.0
http_server_requests_seconds_count{method="GET",uri="/something/4/update"} 4.0
```

With those metrics, it's impossible to filter that method, since  the `uri` is always different. With this fix, the generated metrics are:

```
http_server_requests_seconds_count{method="GET",uri="/something/<myid>/update"} 4.0
http_server_requests_seconds_count{method="GET",uri="/something/<myid>/update"} 4.0
http_server_requests_seconds_count{method="GET",uri="/something/<myid>/update"} 4.0
http_server_requests_seconds_count{method="GET",uri="/something/<myid>/update"} 4.0
```