### PR TITLE
Added command `create-config` (#169)

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -400,7 +400,7 @@ valid-metaclass-classmethod-first-arg=mcs
 max-args=7
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=8
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/pyms/config/__init__.py
+++ b/pyms/config/__init__.py
@@ -1,4 +1,4 @@
-from .conf import get_conf
 from .confile import ConfFile
+from .conf import get_conf, create_conf_file
 
-__all__ = ['get_conf', 'ConfFile']
+__all__ = ['get_conf', 'create_conf_file', 'ConfFile']

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,6 @@
+import os
 from pyms.flask.app import Microservice
+from pyms.constants import CONFIGMAP_FILE_ENVIRONMENT, DEFAULT_CONFIGMAP_FILENAME
 
 class MyMicroserviceNoSingleton(Microservice):
     _singleton = False
@@ -6,3 +8,15 @@ class MyMicroserviceNoSingleton(Microservice):
 
 class MyMicroservice(Microservice):
     pass
+
+
+def remove_conf_file():
+    """
+    Remove the YAML config file
+    """
+    CONFIG_FILE = os.getenv(CONFIGMAP_FILE_ENVIRONMENT, None)
+    if not CONFIG_FILE:
+        CONFIG_FILE = DEFAULT_CONFIGMAP_FILENAME
+    # Dlete file, if exists
+    if os.path.exists(CONFIG_FILE):
+        os.remove(CONFIG_FILE)

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -11,6 +11,7 @@ from pyms.cmd import Command
 from pyms.exceptions import FileDoesNotExistException, PackageNotExists
 from pyms.crypt.fernet import Crypt
 from pyms.flask.services.swagger import get_bundled_specs
+from tests.common import remove_conf_file
 
 
 class TestCmd(unittest.TestCase):
@@ -75,3 +76,13 @@ class TestCmd(unittest.TestCase):
         cmd = Command(arguments=arguments, autorun=False)
         with pytest.raises(ResolutionError) as excinfo:
             cmd.run()
+
+    @patch('pyms.cmd.main.Command.yes_no_input', return_value=True)
+    def test_create_config_all(self, input):
+        # Remove config file if already exists for test
+        remove_conf_file()
+        arguments = ["create-config"]
+        cmd = Command(arguments=arguments, autorun=False)
+        assert cmd.run()
+        assert not cmd.run()
+        remove_conf_file()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from unittest import mock
 
-from pyms.config import get_conf, ConfFile
+from pyms.config import get_conf, ConfFile, create_conf_file
 from pyms.config.conf import validate_conf
 from pyms.constants import CONFIGMAP_FILE_ENVIRONMENT, CONFIGMAP_FILE_ENVIRONMENT_LEGACY, LOGGER_NAME, CONFIG_BASE, \
     CRYPT_FILE_KEY_ENVIRONMENT, CRYPT_FILE_KEY_ENVIRONMENT_LEGACY
@@ -190,3 +190,25 @@ class ConfValidateTests(unittest.TestCase):
         validate_conf()
         os.environ[config_env] = os.path.join(self.BASE_DIR, "config-tests-debug-off.yml")
         validate_conf()
+
+
+class ConfiFileTest(unittest.TestCase):
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    def setUp(self):
+        os.environ[CONFIGMAP_FILE_ENVIRONMENT] = os.path.join(self.BASE_DIR, "config-file.yml")
+
+    def tearDown(self):
+        del os.environ[CONFIGMAP_FILE_ENVIRONMENT]
+
+    def test_create_config(self):
+        create_conf_file(use_requests=True, use_swagger=True)
+        self.assertTrue(os.path.exists(os.environ[CONFIGMAP_FILE_ENVIRONMENT]))
+        validate_conf()
+
+    def test_create_config_failure(self):
+        with self.assertRaises(FileExistsError):
+            create_conf_file(use_requests=True, use_swagger=True)
+        # Delete the file
+        if os.path.exists(os.environ[CONFIGMAP_FILE_ENVIRONMENT]):
+            os.remove(os.environ[CONFIGMAP_FILE_ENVIRONMENT])


### PR DESCRIPTION
- Added command functionality
- Added tests for command
- Added methods to dump, remove config file
NOTE: The command by default, doesn't create/overwrite if a config file
already exists.

Fixes #169 

Changes proposed in this PR:
- Added yaml config generator command